### PR TITLE
Allow registering components without explicitly passing a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Allow registering components without providing a name (e.g. `@component.register()`). In this case, the name of the component's function or class will be used as the component name
 
 ## [0.1.0] - 2023-02-25
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ A component may also be defined as a single function that accepts a `context` an
 from django_web_components import component
 from django_web_components.template import CachedTemplate
 
-@component.register("alert")
+@component.register
 def alert(context):
     return CachedTemplate(
         """
@@ -202,7 +202,7 @@ Regarding caching, the library provides a `CachedTemplate`, which will cache and
 from django_web_components import component
 from django_web_components.template import CachedTemplate
 
-@component.register("alert")
+@component.register
 def alert(context):
     return CachedTemplate(
         """
@@ -641,7 +641,7 @@ The slot content will also have access to the component's context. To explore th
 from django_web_components import component
 from django_web_components.template import CachedTemplate
 
-@component.register("unordered_list")
+@component.register
 def unordered_list(context):
     context["entries"] = context["attributes"].pop("entries", [])
 
@@ -710,7 +710,7 @@ Similar to the components, you may assign additional attributes to slots. Below 
 from django_web_components import component
 from django_web_components.template import CachedTemplate
 
-@component.register("table")
+@component.register
 def table(context):
     context["rows"] = context["attributes"].pop("rows", [])
 
@@ -778,7 +778,7 @@ from django_web_components import component
 from django_web_components.template import CachedTemplate
 import uuid
 
-@component.register("accordion")
+@component.register
 def accordion(context):
     context["accordion_id"] = context["attributes"].pop("id", str(uuid.uuid4()))
     context["always_open"] = context["attributes"].pop("always_open", False)
@@ -793,7 +793,7 @@ def accordion(context):
     ).render(context)
 
 
-@component.register("accordion_item")
+@component.register
 def accordion_item(context):
     context["id"] = context["attributes"].pop("id", str(uuid.uuid4()))
     context["open"] = context["attributes"].pop("open", False)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -894,7 +894,7 @@ class RegisterTest(TestCase):
     def setUp(self) -> None:
         component.registry.clear()
 
-    def test_call_register_as_decorator(self):
+    def test_called_as_decorator_with_name(self):
         @component.register("hello")
         def dummy(context):
             pass
@@ -904,7 +904,27 @@ class RegisterTest(TestCase):
             dummy,
         )
 
-    def test_call_register_directly(self):
+    def test_called_as_decorator_with_no_name(self):
+        @component.register()
+        def hello(context):
+            pass
+
+        self.assertEqual(
+            component.registry.get("hello"),
+            hello,
+        )
+
+    def test_called_as_decorator_with_no_parenthesis(self):
+        @component.register
+        def hello(context):
+            pass
+
+        self.assertEqual(
+            component.registry.get("hello"),
+            hello,
+        )
+
+    def test_called_directly_with_name(self):
         def dummy(context):
             pass
 
@@ -913,4 +933,15 @@ class RegisterTest(TestCase):
         self.assertEqual(
             component.registry.get("hello"),
             dummy,
+        )
+
+    def test_called_directly_with_no_name(self):
+        def hello(context):
+            pass
+
+        component.register(hello)
+
+        self.assertEqual(
+            component.registry.get("hello"),
+            hello,
         )


### PR DESCRIPTION
In this case, the name of the function / class will be used